### PR TITLE
Fix typescript bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ import { createSignal } from 'solid-js';
 import usePopper from 'solid-popper';
 
 function Component() {
-  const [anchor, setAnchor] = createSignal();
-  const [popper, setPopper] = createSignal();
+  const [anchor, setAnchor] = createSignal<HTMLElement>();
+  const [popper, setPopper] = createSignal<HTMLElement>();
 
   usePopper(anchor, popper, {
     placement: 'auto',


### PR DESCRIPTION
Fixes issues raised: #2 #3 
Problem is caused by incorrect typing on `createSignal()` in example. Changing it to `createSignal<HTMLElement>()` resolves the typescript error. 